### PR TITLE
python 3 compatability

### DIFF
--- a/ssync
+++ b/ssync
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import print_function
 import getpass
 import re
 import signal


### PR DESCRIPTION
Mostly just adding parens to print statements but also using the python 3 version of printing to files.
