### PR TITLE
Maybe better protect user quotes

### DIFF
--- a/ssync
+++ b/ssync
@@ -253,8 +253,9 @@ def generateRecursiveHalf(rsyncOptions, head, hosts, user, targetDir):
         qFlags = "-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
     else:
         qFlags = ""
+    rsync_command = string.join(options).replace('"', '\"').replace('$', '\$')    
     command  = "ssh %s %s@%s \"cd %s; %s\"" % (qFlags, user, head,
-                   targetDir, string.join(options))
+                   targetDir, rsync_command)
     return command
 
 # Split the host list in half and recursively call ssync on the target machines


### PR DESCRIPTION
The subsequent code looks like it intends to wrap any user quotes in one layer of double quotes of its own to bundle in directory changing. Therefore, heedlessly escape them in advance.

Probably edge cases where the escaping is both unneeded and noticeable, but those are probably complex enough that the random existing quoting does much worse.

The $ escape I threw in just cause I was very recently solving a very similar problem and that came up as needed. Here, it may not really matter either way, but, who knows.
